### PR TITLE
Use argparse for command argument parser for lfsccm

### DIFF
--- a/lfsccm/.gitignore
+++ b/lfsccm/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info
 build
 .pyc
+**/__pycache__

--- a/lfsccm/bb_lua/burst_buffer.lua
+++ b/lfsccm/bb_lua/burst_buffer.lua
@@ -616,8 +616,8 @@ function _cache_pcc(req_nodes, files)
     -- Check SSH connection
     local cmd = {}
     table.insert(cmd, "lfsccm")
-    table.insert(cmd, "--nodes="..table.concat(node_tbl, ","))
     table.insert(cmd, "check-ssh-connection")
+    table.insert(cmd, "--nodes="..table.concat(node_tbl, ","))
     slurm.log_info("%s: _cache_pcc(). cmd: %s", lua_script_name, table.concat(cmd, " "))
     local _, _, rc = os.execute(table.concat(cmd, " "))
     if rc ~= 0 then
@@ -628,6 +628,7 @@ function _cache_pcc(req_nodes, files)
     -- Cache files
     local cmd = {}
     table.insert(cmd, "lfsccm")
+    table.insert(cmd, "attach")
     table.insert(cmd, "--nodes="..table.concat(node_tbl, ","))
     table.insert(cmd, "--rw-ids="..table.concat(rwid_tbl, ","))
     table.insert(cmd, "--ro-ids="..table.concat(roid_tbl, ","))
@@ -635,7 +636,6 @@ function _cache_pcc(req_nodes, files)
         table.insert(cmd, "--files="..file)
     end
 
-    table.insert(cmd, "attach")
     slurm.log_info("%s: _cache_pcc(). cmd: %s", lua_script_name, table.concat(cmd, " "))
 
     local handle = io.popen(table.concat(cmd, " ").." 2>&1")
@@ -884,10 +884,10 @@ function _check_files(files)
     local err = nil
     local cmd = {}
     table.insert(cmd, "lfsccm")
+    table.insert(cmd, "check-files")
     for _, file in ipairs(files) do
         table.insert(cmd, "--files="..file)
     end
-    table.insert(cmd, "check-files")
     slurm.log_info("%s: _check_files(). cmd: %s", lua_script_name, table.concat(cmd, " "))
 
     local handle = io.popen(table.concat(cmd, " ").." 2>&1")

--- a/lfsccm/lfsccm/main.py
+++ b/lfsccm/lfsccm/main.py
@@ -11,7 +11,6 @@ import logging
 import os
 import paramiko
 import re
-import sys
 from distutils.version import LooseVersion
 from itertools import zip_longest
 from multiprocessing import Pool
@@ -368,10 +367,10 @@ def main() -> int:
         **files_options["kwargs"])
 
     # check-ro-available
-    ro_check_parser = sub_parser.add_parser("check-ro-available")
+    sub_parser.add_parser("check-ro-available")
 
     try:
-                                        args = parser.parse_args()
+        args = parser.parse_args()
     except SystemExit:
         parser.print_help()
         return -1
@@ -387,7 +386,7 @@ def main() -> int:
     nodes = []
     ro_ids = []
     rw_ids = []
-    files =  []
+    files = []
     if hasattr(args, "nodes"):
         nodes = args.nodes
     if hasattr(args, "ro_ids"):

--- a/lfsccm/lfsccm/main.py
+++ b/lfsccm/lfsccm/main.py
@@ -194,14 +194,14 @@ class Pcc(object):
     def _validate_rw_id(self):
         if not self.rw_id:
             raise Exception("Missing rw_id")
-        if not self.rw_id.isdecimal():
-            raise Exception("rw_id is not decimal: {}".format(self.rw_id))
+        if not isinstance(self.rw_id, int):
+            raise Exception("rw_id must be int: {}".format(self.rw_id))
 
     def _validate_ro_id(self):
         if not self.ro_id:
             raise Exception("Missing ro_id")
-        if not self.ro_id.isdecimal():
-            raise Exception("ro_id is not decimal: {}".format(self.ro_id))
+        if not isinstance(self.ro_id, int):
+            raise Exception("ro_id mubst be int: {}".format(self.ro_id))
 
     def _validate_pcc_files(self):
         if not self.pcc_files:
@@ -333,12 +333,6 @@ def parallel_do_action(nodes, action):
     return results
 
 
-def parse_arg(arg):
-    if not arg:
-        return []
-    return arg.replace(' ', '').split(',')
-
-
 def main() -> int:
     logger = setup_logger(__name__)
 
@@ -348,13 +342,13 @@ def main() -> int:
         help="Action verb for operation")
     attach_parser = sub_parser.add_parser("attach")
     # attach
-    for option in ["nodes", "roids", "rwids"]:
+    for option in ["nodes", "roids", "rwids", "files"]:
         attach_parser.add_argument(
             *AVAILABLE_OPTIONS[option]["kargs"],
             **AVAILABLE_OPTIONS[option]["kwargs"])
     # detach
     detach_parser = sub_parser.add_parser("detach")
-    for option in ["nodes", "roids", "rwids"]:
+    for option in ["nodes", "roids", "rwids", "files"]:
         detach_parser.add_argument(
             *AVAILABLE_OPTIONS[option]["kargs"],
             **AVAILABLE_OPTIONS[option]["kwargs"])
@@ -377,7 +371,7 @@ def main() -> int:
     ro_check_parser = sub_parser.add_parser("check-ro-available")
 
     try:
-        args = parser.parse_args()
+                                        args = parser.parse_args()
     except SystemExit:
         parser.print_help()
         return -1
@@ -395,7 +389,7 @@ def main() -> int:
     rw_ids = []
     files =  []
     if hasattr(args, "nodes"):
-        ro_ids = args.nodes
+        nodes = args.nodes
     if hasattr(args, "ro_ids"):
         ro_ids = args.ro_ids
     if hasattr(args, "rw_ids"):

--- a/lfsccm/lfsccm/tests/test_main.py
+++ b/lfsccm/lfsccm/tests/test_main.py
@@ -45,20 +45,13 @@ class TestMain(BaseTestMain):
     argv = "lfsccm"
 
     def test_main_no_action(self):
-        with self.assertRaises(SystemExit):
-            # FIXME: later than python 3.9, we could use exit_on_error
-            # instead of bare syste exit on argument error
-            # https://docs.python.org/ja/3/library/argparse.html#exit-on-error
-            main.main()
+        self.assertEqual(-1, main.main())
 
 
 @mock.patch("paramiko.client.SSHClient.connect")
 @mock.patch("paramiko.client.SSHClient.exec_command")
 class TestMainCheckFiles(BaseTestMain):
-    # FIXME: use something like optparse to add options in anywhare
-    # in the args, and handle syntax errors to notify what was wrong
-    # with in the errors.
-    argv = "lfsccm --files=/sample/file:ro:0 check-files"
+    argv = "lfsccm check-files --files=/sample/file:ro:0"
 
     @mock.patch("sys.argv", ["lfsccm", "check-files"])
     def test_check_files_no_files_specified(self, mock_exec, mock_connect):

--- a/lfsccm/lfsccm/tests/test_main.py
+++ b/lfsccm/lfsccm/tests/test_main.py
@@ -45,7 +45,11 @@ class TestMain(BaseTestMain):
     argv = "lfsccm"
 
     def test_main_no_action(self):
-        self.assertEqual(-1, main.main())
+        with self.assertRaises(SystemExit):
+            # FIXME: later than python 3.9, we could use exit_on_error
+            # instead of bare syste exit on argument error
+            # https://docs.python.org/ja/3/library/argparse.html#exit-on-error
+            main.main()
 
 
 @mock.patch("paramiko.client.SSHClient.connect")


### PR DESCRIPTION
For testing perspective, C lang like getopt  would be complex to generate flexible configuration and the option syntax check. With those commits in this PR, the newer lfsccm is going to use python native argparse library and make all actions command to subargument to ensure the required options into the subcommands. 