### PR TITLE
Fix demo script to keep it as idempotent

### DIFF
--- a/lustre-vm/slurm/install.sh
+++ b/lustre-vm/slurm/install.sh
@@ -50,5 +50,7 @@ sudo systemctl enable --now slurmd
 sudo ssh-keygen -N "" -f /root/.ssh/id_rsa
 sudo sh -c "cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys"
 # for idempotent way, remove older host entity from known_hosts file
+set +e
 sudo ssh-keygen -R lima-lustre
+set -e
 sudo ssh -o StrictHostKeyChecking=no root@lima-lustre exit


### PR DESCRIPTION
current demo script fails if it runs for a few times because the ssh key generation raises non-zero exit code when the key exists. this pull request fixes the issue by add `set +e` and ignore the existence warning.